### PR TITLE
[feat] 질문 엔티티, dto생성 및 기본 파일 구조 추가

### DIFF
--- a/backend/src/main/java/com/backend/api/question/controller/AdminQuestionController.java
+++ b/backend/src/main/java/com/backend/api/question/controller/AdminQuestionController.java
@@ -1,0 +1,4 @@
+package com.backend.api.question.controller;
+
+public class AdminQuestionController {
+}

--- a/backend/src/main/java/com/backend/api/question/controller/QuestionController.java
+++ b/backend/src/main/java/com/backend/api/question/controller/QuestionController.java
@@ -1,0 +1,4 @@
+package com.backend.api.question.controller;
+
+public class QuestionController {
+}

--- a/backend/src/main/java/com/backend/api/question/service/AdminQuestionService.java
+++ b/backend/src/main/java/com/backend/api/question/service/AdminQuestionService.java
@@ -1,0 +1,4 @@
+package com.backend.api.question.service;
+
+public class AdminQuestionService {
+}

--- a/backend/src/main/java/com/backend/api/question/service/QuestionService.java
+++ b/backend/src/main/java/com/backend/api/question/service/QuestionService.java
@@ -1,0 +1,4 @@
+package com.backend.api.question.service;
+
+public class QuestionService {
+}

--- a/backend/src/main/java/com/backend/domain/question/dto/request/AdminQuestionAddRequest.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/request/AdminQuestionAddRequest.java
@@ -1,0 +1,27 @@
+package com.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+
+import java.util.List;
+
+public record AdminQuestionAddRequest (
+    @NotBlank(message = "질문 제목은 필수입니다.")
+    @Schema(description = "질문 제목", example = "Spring Bean의 생명주기는 어떻게 되나요?")
+    String title,
+
+    @NotBlank(message = "질문 내용은 필수입니다.")
+    @Schema(description = "질문 내용", example = "Bean이 생성되고 초기화되고 소멸되는 과정에 대해 설명해주세요.")
+    String content,
+
+    @Schema(description = "카테고리 ID 목록", example = "[1, 2, 3]")
+    List<Long> categoryIds,
+
+    @Schema(description = "승인 여부", example = "true")
+    Boolean isApproved,
+
+    @PositiveOrZero(message = "점수는 0 이상이어야 합니다.")
+    @Schema(description = "초기 점수", example = "10")
+    Integer score
+) {}

--- a/backend/src/main/java/com/backend/domain/question/dto/request/QuestionAddRequest.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/request/QuestionAddRequest.java
@@ -1,0 +1,20 @@
+package com.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record QuestionAddRequest (
+        @NotBlank(message = "질문 제목은 필수입니다.")
+        @Schema(description = "질문 제목", example = "Spring Bean의 생명주기는 어떻게 되나요?")
+        String title,
+
+        @NotBlank(message = "질문 내용은 필수입니다.")
+        @Schema(description = "질문 내용", example = "Bean이 생성되고 초기화되고 소멸되는 과정에 대해 설명해주세요.")
+        String content,
+
+        @Schema(description = "카테고리 ID 목록", example = "[1, 2, 3]")
+        List<Long> categoryIds
+) {}

--- a/backend/src/main/java/com/backend/domain/question/dto/request/QuestionApproveRequest.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/request/QuestionApproveRequest.java
@@ -1,0 +1,8 @@
+package com.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record QuestionApproveRequest(
+        @Schema(description = "승인 여부", example = "true")
+        Boolean isApproved
+) {}

--- a/backend/src/main/java/com/backend/domain/question/dto/request/QuestionScoreRequest.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/request/QuestionScoreRequest.java
@@ -1,0 +1,10 @@
+package com.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+
+public record QuestionScoreRequest(
+        @Min(value = 0, message = "점수는 0 이상이어야 합니다.")
+        @Schema(description = "질문 점수", example = "5")
+        Integer score
+) {}

--- a/backend/src/main/java/com/backend/domain/question/dto/request/QuestionUpdateRequest.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/request/QuestionUpdateRequest.java
@@ -1,0 +1,20 @@
+package com.backend.domain.question.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record QuestionUpdateRequest(
+        @NotBlank(message = "질문 제목은 필수입니다.")
+        @Schema(description = "질문 제목", example = "수정할 제목")
+        String title,
+
+        @NotBlank(message = "질문 내용은 필수입니다.")
+        @Schema(description = "질문 내용", example = "수정할 내용")
+        String content,
+
+        @Schema(description = "카테고리 ID 목록", example = "[1, 4]")
+        List<Long> categoryIds
+) {}

--- a/backend/src/main/java/com/backend/domain/question/dto/response/QuestionResponse.java
+++ b/backend/src/main/java/com/backend/domain/question/dto/response/QuestionResponse.java
@@ -1,0 +1,33 @@
+package com.backend.domain.question.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record QuestionResponse(
+        @Schema(description = "질문 ID", example = "1")
+        Long questionId,
+
+        @Schema(description = "질문 제목", example = "Spring Bean의 생명주기는 어떻게 되나요?")
+        String title,
+
+        @Schema(description = "질문 내용", example = "Bean의 생성과 소멸 과정에 대해 설명해주세요.")
+        String content,
+
+        @Schema(description = "승인 여부", example = "false")
+        Boolean isApproved,
+
+        @Schema(description = "점수", example = "5")
+        Integer score,
+
+        @Schema(description = "카테고리 ID 목록", example = "[1, 2]")
+        List<Long> categoryIds,
+
+        @Schema(description = "작성일", example = "2025-10-13T11:00:00")
+        LocalDateTime createdAt,
+
+        @Schema(description = "수정일", example = "2025-10-13T12:00:00")
+        LocalDateTime modifiedAt
+) {
+}

--- a/backend/src/main/java/com/backend/domain/question/entity/Questions.java
+++ b/backend/src/main/java/com/backend/domain/question/entity/Questions.java
@@ -1,0 +1,37 @@
+package com.backend.domain.question.entity;
+
+import com.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name="questions")
+@Getter
+@NoArgsConstructor
+public class Questions extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long questionId;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @Column(nullable = true)
+    private Boolean isApproved = false; // 0: 미승인, 1: 승인
+
+    @Column(nullable = false)
+    private Integer score = 0; // 기본값 0
+
+    @Builder
+    public Questions(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+
+}

--- a/backend/src/main/java/com/backend/domain/question/repository/QuestionRepository.java
+++ b/backend/src/main/java/com/backend/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,8 @@
+package com.backend.domain.question.repository;
+
+import com.backend.domain.question.entity.Questions;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionRepository extends JpaRepository<Questions,Integer> {
+
+}


### PR DESCRIPTION
## 📝 작업 개요
- 질문(Question) 도메인 초기 세팅
- 질문 관련 엔티티, DTO(request/response) 및 Repository 기본 구조 생성

## 🔗 관련 이슈
- Close #3 

## 🔍 작업 내용
- `Questions` 엔티티 생성 (`questionId`, `title`, `content`, `isApproved`, `score` 등 기본 필드 정의)  
- 요청/응답용 DTO 생성  
  - `QuestionAddRequest`, `AdminQuestionAddRequest`, `QuestionUpdateRequest`, `QuestionScoreRequest`, `QuestionApproveRequest`, `QuestionResponse`  
- `QuestionRepository` 인터페이스 기본 세팅 (JpaRepository 상속)  
- 패키지 구조 정리 (`entity`, `dto.request`, `dto.response`, `repository`)

## ✅ 체크리스트
- [x] 코드에 오류가 없음
- [ ] 테스트 코드 작성/수행 완료
- [x] 팀 내 코드 스타일 가이드 준수
- [x] 이슈 연결 여부
      
