### PR TITLE
[fix] id 중복 수정 및 dto 이동

### DIFF
--- a/backend/src/main/java/com/backend/api/post/dto/request/PostAddRequest.java
+++ b/backend/src/main/java/com/backend/api/post/dto/request/PostAddRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.post.dto.request;
+package com.backend.api.post.dto.request;
 
 import com.backend.domain.post.entity.PinStatus;
 import com.backend.domain.post.entity.PostStatus;

--- a/backend/src/main/java/com/backend/api/post/dto/request/PostUpdateRequest.java
+++ b/backend/src/main/java/com/backend/api/post/dto/request/PostUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.post.dto.request;
+package com.backend.api.post.dto.request;
 
 import com.backend.domain.post.entity.PinStatus;
 import com.backend.domain.post.entity.PostStatus;

--- a/backend/src/main/java/com/backend/api/post/dto/response/PostResponse.java
+++ b/backend/src/main/java/com/backend/api/post/dto/response/PostResponse.java
@@ -1,4 +1,4 @@
-package com.backend.domain.post.dto.response;
+package com.backend.api.post.dto.response;
 
 import com.backend.domain.post.entity.PinStatus;
 import com.backend.domain.post.entity.Post;

--- a/backend/src/main/java/com/backend/api/question/dto/request/AdminQuestionAddRequest.java
+++ b/backend/src/main/java/com/backend/api/question/dto/request/AdminQuestionAddRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.request;
+package com.backend.api.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/backend/api/question/dto/request/QuestionAddRequest.java
+++ b/backend/src/main/java/com/backend/api/question/dto/request/QuestionAddRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.request;
+package com.backend.api.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/backend/api/question/dto/request/QuestionApproveRequest.java
+++ b/backend/src/main/java/com/backend/api/question/dto/request/QuestionApproveRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.request;
+package com.backend.api.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/backend/src/main/java/com/backend/api/question/dto/request/QuestionScoreRequest.java
+++ b/backend/src/main/java/com/backend/api/question/dto/request/QuestionScoreRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.request;
+package com.backend.api.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;

--- a/backend/src/main/java/com/backend/api/question/dto/request/QuestionUpdateRequest.java
+++ b/backend/src/main/java/com/backend/api/question/dto/request/QuestionUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.request;
+package com.backend.api.question.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/src/main/java/com/backend/api/question/dto/response/QuestionResponse.java
+++ b/backend/src/main/java/com/backend/api/question/dto/response/QuestionResponse.java
@@ -1,4 +1,4 @@
-package com.backend.domain.question.dto.response;
+package com.backend.api.question.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/backend/src/main/java/com/backend/api/user/dto/request/UserLoginRequest.java
+++ b/backend/src/main/java/com/backend/api/user/dto/request/UserLoginRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.user.dto.request;
+package com.backend.api.user.dto.request;
 
 import com.backend.domain.user.entity.Users;
 import jakarta.validation.constraints.Email;

--- a/backend/src/main/java/com/backend/api/user/dto/request/UserSignupRequest.java
+++ b/backend/src/main/java/com/backend/api/user/dto/request/UserSignupRequest.java
@@ -1,4 +1,4 @@
-package com.backend.domain.user.dto.request;
+package com.backend.api.user.dto.request;
 
 import com.backend.domain.user.entity.Users;
 import jakarta.validation.constraints.Email;

--- a/backend/src/main/java/com/backend/api/user/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/backend/api/user/dto/response/UserResponse.java
@@ -1,4 +1,4 @@
-package com.backend.domain.user.dto.response;
+package com.backend.api.user.dto.response;
 
 import com.backend.domain.user.entity.Users;
 

--- a/backend/src/main/java/com/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/api/user/service/UserService.java
@@ -1,6 +1,6 @@
 package com.backend.api.user.service;
 
-import com.backend.domain.user.dto.request.UserSignupRequest;
+import com.backend.api.user.dto.request.UserSignupRequest;
 import com.backend.domain.user.entity.Users;
 import com.backend.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/com/backend/domain/question/entity/Questions.java
+++ b/backend/src/main/java/com/backend/domain/question/entity/Questions.java
@@ -12,10 +12,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Questions extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long questionId;
-
     @Column(nullable = false, length = 100)
     private String title;
 

--- a/backend/src/main/java/com/backend/domain/user/entity/Users.java
+++ b/backend/src/main/java/com/backend/domain/user/entity/Users.java
@@ -1,6 +1,6 @@
 package com.backend.domain.user.entity;
 
-import com.backend.domain.user.dto.request.UserSignupRequest;
+import com.backend.api.user.dto.request.UserSignupRequest;
 import com.backend.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;


### PR DESCRIPTION
## 📝 작업 개요
- **Question** 테이블의 `id` 필드 중복 문제 해결  
- `dto` 패키지 파일 위치를 도메인 구조에 맞게 정리

## 🔗 관련 이슈
- Close #22

## 🔍 작업 내용
- `Questions` 엔티티에서 `questionId` 필드 제거 → `BaseEntity`의 `id` 상속 사용
- `dto` 디렉토리 구조 정리

## ✅ 체크리스트
- [x] 코드에 오류가 없음
- [ ] 테스트 코드 작성/수행 완료
- [x] 팀 내 코드 스타일 가이드 준수
- [x] 이슈 연결 여부
      
