### PR TITLE
[refactor] 질문 엔티티의 예외 처리 로직을 서비스 계층으로 이동

### DIFF
--- a/backend/src/main/java/com/backend/api/question/service/AdminQuestionService.java
+++ b/backend/src/main/java/com/backend/api/question/service/AdminQuestionService.java
@@ -43,7 +43,6 @@ public class AdminQuestionService {
     @Transactional
     public QuestionResponse addQuestion(@Valid AdminQuestionAddRequest request, User user) {
         validateAdminAuthority(user);
-        validateQuestionRequest(request.title(), request.content());
         Question question = createQuestion(request, user);
         Question saved = saveQuestion(question);
         return QuestionResponse.from(saved);
@@ -57,10 +56,10 @@ public class AdminQuestionService {
                 .build();
 
         if (request.isApproved() != null) {
-            question.setApproved(request.isApproved());
+            question.updateApproved(request.isApproved());
         }
         if (request.score() != null) {
-            question.setScore(request.score());
+            question.updateScore(request.score());
         }
 
         return question;
@@ -74,7 +73,6 @@ public class AdminQuestionService {
     @Transactional
     public QuestionResponse updateQuestion(Long questionId, @Valid AdminQuestionUpdateRequest request, User user) {
         validateAdminAuthority(user);
-        validateQuestionRequest(request.title(), request.content());
         Question question = findByIdOrThrow(questionId);
         updateAdminQuestion(question, request);
         return QuestionResponse.from(question);
@@ -89,22 +87,12 @@ public class AdminQuestionService {
         );
     }
 
-    private void validateQuestionRequest(String title, String content) {
-        if (title == null || title.isBlank()) {
-            throw new ErrorException(ErrorCode.QUESTION_TITLE_NOT_BLANK);
-        }
-        if (content == null || content.isBlank()) {
-            throw new ErrorException(ErrorCode.QUESTION_CONTENT_NOT_BLANK);
-        }
-    }
-
-
     // 질문 승인/비승인 처리
     @Transactional
     public QuestionResponse approveQuestion(Long questionId, boolean isApproved, User user) {
         validateAdminAuthority(user);
         Question question = findByIdOrThrow(questionId);
-        question.setApproved(isApproved);
+        question.updateApproved(isApproved);
         return QuestionResponse.from(question);
     }
 
@@ -113,7 +101,7 @@ public class AdminQuestionService {
     public QuestionResponse setQuestionScore(Long questionId, Integer score, User user) {
         validateAdminAuthority(user);
         Question question = findByIdOrThrow(questionId);
-        question.setScore(score);
+        question.updateScore(score);
         return QuestionResponse.from(question);
     }
 

--- a/backend/src/main/java/com/backend/api/question/service/QuestionService.java
+++ b/backend/src/main/java/com/backend/api/question/service/QuestionService.java
@@ -56,7 +56,6 @@ public class QuestionService {
     @Transactional
     public QuestionResponse addQuestion(@Valid QuestionAddRequest request, User user) {
         validateUserAuthority(user);
-        validateQuestionRequest(request.title(),  request.content());
         Question question = createQuestion(request, user);
         Question saved = saveQuestion(question);
         return QuestionResponse.from(saved);
@@ -80,7 +79,6 @@ public class QuestionService {
         validateUserAuthority(user);
         Question question = findByIdOrThrow(questionId);
         validateQuestionAuthor(question, user);
-        validateQuestionRequest(request.title(), request.content());
 
         updateQuestionContent(question, request);
         return QuestionResponse.from(question);
@@ -88,15 +86,6 @@ public class QuestionService {
 
     private void updateQuestionContent(Question question, QuestionUpdateRequest request) {
         question.updateUserQuestion(request.title(), request.content());
-    }
-
-    private void validateQuestionRequest(String title, String content) {
-        if (title == null || title.isBlank()) {
-            throw new ErrorException(ErrorCode.QUESTION_TITLE_NOT_BLANK);
-        }
-        if (content == null || content.isBlank()) {
-            throw new ErrorException(ErrorCode.QUESTION_CONTENT_NOT_BLANK);
-        }
     }
 
     //승인된 질문 전체 조회

--- a/backend/src/main/java/com/backend/domain/question/entity/Question.java
+++ b/backend/src/main/java/com/backend/domain/question/entity/Question.java
@@ -37,11 +37,11 @@ public class Question extends BaseEntity {
         this.author = author;
     }
 
-    public void setApproved(Boolean isApproved) {
+    public void updateApproved(Boolean isApproved) {
         this.isApproved = isApproved;
     }
 
-    public void setScore(Integer score) { this.score = score; }
+    public void updateScore(Integer newScore) { this.score = newScore; }
 
     public void updateUserQuestion(String title, String content) {
         this.title = title;
@@ -57,7 +57,7 @@ public class Question extends BaseEntity {
         }
 
         if(score != null) {
-            setScore(score);
+            updateScore(score);
         }
     }
 }


### PR DESCRIPTION
## 📝 작업 개요
- Question 엔티티 내부에서 수행하던 예외 처리 로직(ErrorException, ErrorCode)을 서비스 계층으로 이동

## 🔗 관련 이슈
- Close #102 

## 🔍 작업 내용
- Question 엔티티 내부의 validateTitleAndContent, setScore 내 예외 처리 로직 제거
- AdminQuestionService, QuestionService에서 입력값(title, content, score 등)에 대한 검증 로직 추가

## ✅ 체크리스트
- [x] 코드에 오류가 없음
- [x] 테스트 코드 작성/수행 완료
- [x] 팀 내 코드 스타일 가이드 준수
- [x] 이슈 연결 여부
      
