### PR TITLE
[feat] 계정 상태에 따른 예외 처리 추가

### DIFF
--- a/backend/src/main/java/com/backend/api/comment/service/CommentService.java
+++ b/backend/src/main/java/com/backend/api/comment/service/CommentService.java
@@ -25,6 +25,10 @@ public class CommentService {
     @Transactional
     public Comment writeComment(User user, Long postId, String content) {
 
+        if (!user.validateActiveStatus()) {
+            throw new ErrorException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+
         Post post = postService.findPostByIdOrThrow(postId);
 
         Comment comment = Comment.builder()

--- a/backend/src/main/java/com/backend/api/post/service/PostService.java
+++ b/backend/src/main/java/com/backend/api/post/service/PostService.java
@@ -20,6 +20,10 @@ public class PostService {
 
     @Transactional
     public PostResponse createPost(PostAddRequest request, User user) {
+        if (!user.validateActiveStatus()) {
+            throw new ErrorException(ErrorCode.ACCOUNT_SUSPENDED);
+        }
+
         Post post = Post.builder()
                 .title(request.title())
                 .content(request.content())

--- a/backend/src/main/java/com/backend/api/user/service/UserService.java
+++ b/backend/src/main/java/com/backend/api/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.backend.api.user.service;
 import com.backend.api.user.dto.request.UserLoginRequest;
 import com.backend.api.user.dto.request.UserSignupRequest;
 import com.backend.api.user.dto.response.TokenResponse;
+import com.backend.domain.user.entity.AccountStatus;
 import com.backend.domain.user.entity.Role;
 import com.backend.api.user.dto.response.UserMyPageResponse;
 import com.backend.domain.user.entity.User;
@@ -46,6 +47,15 @@ public class UserService {
     public User login(UserLoginRequest request){
         User user = userRepository.findByEmail(request.email())
                 .orElseThrow(() -> new ErrorException(ErrorCode.NOT_FOUND_EMAIL));
+
+        if(!user.validateLoginAvaliable()) {
+            if(user.getAccountStatus() == AccountStatus.BANNED) {
+                throw new ErrorException(ErrorCode.ACCOUNT_BANNED);
+            }
+            if(user.getAccountStatus() == AccountStatus.DEACTIVATED) {
+                throw new ErrorException(ErrorCode.ACCOUNT_DEACTIVATED);
+            }
+        }
 
         if(!passwordEncoder.matches(request.password(), user.getPassword())){
             throw new ErrorException(ErrorCode.WRONG_PASSWORD);

--- a/backend/src/main/java/com/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/backend/domain/user/entity/User.java
@@ -75,4 +75,12 @@ public class User extends BaseEntity {
             this.accountStatus = newStatus;
         }
     }
+
+    public boolean validateActiveStatus() {
+        return this.accountStatus == AccountStatus.ACTIVE;
+    }
+
+    public boolean validateLoginAvaliable() {
+        return this.accountStatus == AccountStatus.ACTIVE || this.accountStatus == AccountStatus.SUSPENDED;
+    }
 }


### PR DESCRIPTION
## 📝 작업 개요
- 계정 상태(AccountStatus)에 따라 특정 기능(게시글/댓글 작성 등)을 제한하는 예외 처리 로직 추가
- 계정 상태에 따라 로그인 가능 여부 예외 처리 추가

## 🔗 관련 이슈
- Close #91 

## 🔍 작업 내용
- User 엔티티에 validateActiveStatus() 및 validateLoginAvailable() 메서드 추가
- PostService, CommentService 내에서 계정 상태 검증 로직 추가
- 로그인 시 DEACTIVATED, BANNED 상태 사용자는 로그인 불가 처리

## ✅ 체크리스트
- [x] 코드에 오류가 없음
- [ ] 테스트 코드 작성/수행 완료
- [x] 팀 내 코드 스타일 가이드 준수
- [x] 이슈 연결 여부
      
